### PR TITLE
Ensure complete verified event buckets

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test:content-refill": "node --experimental-strip-types scripts/verify-content-refill.mjs",
     "test:gemini-cache": "npx --yes tsx scripts/verify-gemini-cache.ts",
     "typecheck": "tsc --noEmit"
   },

--- a/scripts/verify-content-refill.mjs
+++ b/scripts/verify-content-refill.mjs
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { hasMinimumEvents, mergeValidatedSelections } from '../src/lib/historical-event-selection.ts';
+
+const event = (title, source, rank) => ({
+  title,
+  source,
+  significanceRank: rank,
+  date: '2026-08-06',
+  category: 'Science',
+  description: title,
+});
+
+const merged = mergeValidatedSelections(
+  { count: 2, events: [event('One', 'https://example.com/1', 1), event('Two', 'https://example.com/2', 2)] },
+  { count: 3, events: [event('Two', 'https://example.com/duplicate', 1), event('Three', 'https://example.com/3', 2), event('Four', 'https://example.com/4', 3)] }
+);
+
+assert.equal(merged.count, 3);
+assert.deepEqual(merged.events.map(item => item.title), ['One', 'Two', 'Three', 'Four']);
+assert.equal(hasMinimumEvents(merged), true);
+assert.equal(hasMinimumEvents({ count: 2, events: merged.events.slice(0, 2) }), false);
+
+const dynamic = mergeValidatedSelections(
+  { count: 5, events: [1, 2, 3, 4, 5].map(index => event(`Dynamic ${index}`, `https://example.com/dynamic-${index}`, index)) },
+  { count: 0, events: [] }
+);
+
+assert.equal(dynamic.count, 5);
+
+console.log('Content refill selection check passed');

--- a/src/ai/flows/generate-historical-events.ts
+++ b/src/ai/flows/generate-historical-events.ts
@@ -10,11 +10,12 @@
 import {ai} from '@/ai/ai-instance';
 import {z} from 'genkit';
 import {getTTLUntilEndOfWeek, getTTLUntilMidnight} from '@/lib/cache-file';
-import {HISTORICAL_EVENT_CATEGORIES} from '@/lib/historical-event-categories';
+import {HISTORICAL_EVENT_CATEGORIES, type HistoricalEventCategory} from '@/lib/historical-event-categories';
 import {GEMINI_CACHE_MODEL, resolveGeminiContextCache} from '@/lib/gemini-context-cache';
 import {
   buildBatchEventPrompt,
   buildBatchEventWeekPrompt,
+  buildRefillEventPrompt,
   buildSingleEventPrompt,
   buildSingleEventWeekPrompt,
 } from '@/lib/gemini-prompt-builders';
@@ -174,6 +175,10 @@ const HistoricalEventSelectionSchema = z.object({
   events: z.array(HistoricalEventSchema).describe('The ranked candidate events ordered from most significant to least significant.'),
 });
 
+const HistoricalEventRefillSchema = z.object({
+  events: z.array(HistoricalEventSchema),
+});
+
 const GenerateHistoricalEventsOutputSchema = HistoricalEventSelectionSchema;
 export type GenerateHistoricalEventsOutput = z.infer<typeof GenerateHistoricalEventsOutputSchema>;
 
@@ -189,6 +194,13 @@ const HistoricalEventsByCategorySchema = z.object({
 });
 
 export type HistoricalEventsByCategory = z.infer<typeof HistoricalEventsByCategorySchema>;
+
+export type GenerateHistoricalEventRefillInput = {
+  date: string;
+  viewType: 'today' | 'week';
+  categories: HistoricalEventCategory[];
+  excludedEvents: Array<Pick<z.infer<typeof HistoricalEventSchema>, 'category' | 'title' | 'source'>>;
+};
 
 const HISTORICAL_EVENTS_GENERATION_MODEL = 'googleai/gemini-3-flash-preview';
 
@@ -388,6 +400,44 @@ export async function generateHistoricalEventsByCategory(input: GenerateHistoric
   }
 }
 
+export async function generateHistoricalEventRefill(input: GenerateHistoricalEventRefillInput): Promise<HistoricalEventsByCategory> {
+  try {
+    const weekInfo = input.viewType === 'week' ? getWeekDateRange(input.date) : undefined;
+    const output = await generateGeminiJson({
+      prompt: buildRefillEventPrompt({
+        date: input.date,
+        categories: input.categories,
+        excludedEvents: input.excludedEvents,
+        weekInfo,
+      }),
+      outputSchema: HistoricalEventRefillSchema,
+    });
+    const requestedCategories = new Set(input.categories);
+    const selections = emptyCategorySelectionMap();
+
+    for (const event of output?.events || []) {
+      if (requestedCategories.has(event.category)) {
+        selections[event.category].events.push(event);
+      }
+    }
+
+    for (const category of input.categories) {
+      selections[category].count = 3;
+    }
+
+    if (weekInfo) {
+      return normalizeSelectionsByCategory(filterByDateRangeForCategories(selections, weekInfo.startDate, weekInfo.endDate));
+    }
+
+    const [, month, day] = input.date.split('-');
+    const mmdd = `${month}-${day}`;
+    return normalizeSelectionsByCategory(filterByDateRangeForCategories(selections, mmdd, mmdd));
+  } catch (error) {
+    console.error('Error generating historical event refills:', error);
+    return emptyCategorySelectionMap();
+  }
+}
+
 const generateHistoricalEventsFlow = ai.defineFlow<
   typeof GenerateHistoricalEventsInputSchema,
   typeof GenerateHistoricalEventsOutputSchema
@@ -518,4 +568,3 @@ function normalizeSelectionsByCategory(eventsByCategory: HistoricalEventsByCateg
     Literature: normalizeSelection(eventsByCategory.Literature || emptyHistoricalEventSelection()),
   };
 }
-

--- a/src/app/api/historical-events/route.ts
+++ b/src/app/api/historical-events/route.ts
@@ -1,5 +1,10 @@
 import { after, NextRequest, NextResponse } from 'next/server';
-import { generateHistoricalEvents, generateHistoricalEventsByCategory, type HistoricalEventsByCategory } from '@/ai/flows/generate-historical-events';
+import {
+  generateHistoricalEventRefill,
+  generateHistoricalEvents,
+  generateHistoricalEventsByCategory,
+  type HistoricalEventsByCategory,
+} from '@/ai/flows/generate-historical-events';
 import { 
   acquireCacheLock,
   releaseCacheLock,
@@ -15,11 +20,17 @@ import { normalizeCacheDate } from '@/lib/cache-keys';
 import { filterHiddenContent } from '@/lib/report-cache';
 import { getReportStats } from '@/lib/report-cache';
 import { HISTORICAL_EVENT_CATEGORIES, type HistoricalEventCategory } from '@/lib/historical-event-categories';
+import {
+  hasMinimumEvents,
+  mergeValidatedSelections,
+} from '@/lib/historical-event-selection';
 
-const CACHE_VERSION = 'v6';
+const CACHE_VERSION = 'v10';
 const GENERATION_LOCK_TTL_MS = 4 * 60 * 1000;
 const GENERATION_LOCK_WAIT_MS = 4 * 60 * 1000;
 const GENERATION_LOCK_POLL_MS = 1000;
+const SOURCE_URL_TIMEOUT_MS = 5000;
+const SOURCE_HTML_PREFIX_BYTES = 16 * 1024;
 
 export const maxDuration = 300;
 
@@ -36,8 +47,104 @@ function buildReportCacheRevision(stats: Awaited<ReturnType<typeof getReportStat
   ].join(':');
 }
 
-function isEmptySelection(selection?: CachedHistoricalEventSelection | null): boolean {
-  return !selection || selection.count <= 0 || !Array.isArray(selection.events) || selection.events.length === 0;
+function normalizeSourceUrl(source: string): string | undefined {
+  try {
+    const url = new URL(source.trim());
+
+    if (!['http:', 'https:'].includes(url.protocol) || !url.hostname || url.username || url.password) {
+      return undefined;
+    }
+
+    url.hash = '';
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+// ponytail: checks URL reachability, not fact-to-page semantics; use grounded search when proof is required.
+async function validateSourceUrl(source: string): Promise<string> {
+  const normalizedSource = normalizeSourceUrl(source);
+  if (!normalizedSource) {
+    return '';
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), SOURCE_URL_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(normalizedSource, {
+      headers: { Range: `bytes=0-${SOURCE_HTML_PREFIX_BYTES - 1}` },
+      redirect: 'follow',
+      signal: controller.signal,
+    });
+    const contentType = response.headers.get('content-type')?.toLowerCase() || '';
+    const isHtml = contentType.includes('text/html');
+    const isPdf = contentType.includes('application/pdf');
+
+    if (![200, 206].includes(response.status) || (!isHtml && !isPdf)) {
+      return '';
+    }
+
+    if (isHtml && response.body) {
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let html = '';
+      let bytesRead = 0;
+
+      try {
+        while (bytesRead < SOURCE_HTML_PREFIX_BYTES) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          const chunk = value.subarray(0, SOURCE_HTML_PREFIX_BYTES - bytesRead);
+          html += decoder.decode(chunk, { stream: true });
+          bytesRead += chunk.byteLength;
+        }
+        html += decoder.decode();
+      } finally {
+        await reader.cancel().catch(() => undefined);
+      }
+
+      const pageHeadings = [...html.matchAll(/<(?:title|h1)\b[^>]*>([\s\S]*?)<\/(?:title|h1)>/gi)]
+        .map(match => match[1].replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim())
+        .join(' ');
+
+      if (/\b404\b|page not found|\bnot found\b|page unavailable|content unavailable/i.test(pageHeadings)) {
+        return '';
+      }
+    }
+
+    return normalizeSourceUrl(response.url) || normalizedSource;
+  } catch {
+    return '';
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function validateSelectionSources(selection: CachedHistoricalEventSelection): Promise<CachedHistoricalEventSelection> {
+  const checkedEvents = await Promise.all(
+    selection.events.map(async event => {
+      const source = await validateSourceUrl(event.source);
+      return source ? { ...event, source } : undefined;
+    })
+  );
+  const validEvents = checkedEvents.filter((event): event is CachedHistoricalEvent => Boolean(event));
+  const visibleEvents = await filterHiddenContent(validEvents);
+
+  return { count: selection.count, events: visibleEvents };
+}
+
+async function validateCategorySources(selections: HistoricalEventsByCategory): Promise<HistoricalEventsByCategory> {
+  const entries = await Promise.all(
+    HISTORICAL_EVENT_CATEGORIES.map(async category => [
+      category,
+      await validateSelectionSources(selections[category] || emptySelection()),
+    ] as const)
+  );
+
+  return Object.fromEntries(entries) as HistoricalEventsByCategory;
 }
 
 function getGenerationLockKey(date: string, viewType: 'today' | 'week', scope: 'batch' | HistoricalEventCategory): string {
@@ -51,11 +158,22 @@ async function getCachedSingleCategoryResponse(cacheKey: string): Promise<Cached
   }
 
   const cachedSelection = await getCacheData(cacheKey);
-  return isEmptySelection(cachedSelection) ? undefined : cachedSelection;
+  if (!hasMinimumEvents(cachedSelection)) {
+    return undefined;
+  }
+
+  return (await getVisibleSelection(cachedSelection)).length >= 3 ? cachedSelection : undefined;
 }
 
 async function getCachedBatchResponse(date: string, viewType: 'today' | 'week'): Promise<HistoricalEventsByCategory | undefined> {
-  const cacheKeys = HISTORICAL_EVENT_CATEGORIES.map(currentCategory => {
+  const selectionsByCategory = await getCachedSelectionsByCategory(date, viewType);
+  const hasCompleteBatch = HISTORICAL_EVENT_CATEGORIES.every(category => hasMinimumEvents(selectionsByCategory[category]));
+
+  return hasCompleteBatch ? selectionsByCategory : undefined;
+}
+
+async function getCachedSelectionsByCategory(date: string, viewType: 'today' | 'week'): Promise<HistoricalEventsByCategory> {
+  const entries = await Promise.all(HISTORICAL_EVENT_CATEGORIES.map(async currentCategory => {
     const cacheKey: CacheKey = {
       date,
       category: currentCategory,
@@ -63,39 +181,14 @@ async function getCachedBatchResponse(date: string, viewType: 'today' | 'week'):
       version: CACHE_VERSION,
     };
 
-    return {
-      category: currentCategory,
-      key: generateCacheKey(cacheKey),
-    };
-  });
+    return [currentCategory, await getCachedSingleCategoryResponse(generateCacheKey(cacheKey)) || emptySelection()] as const;
+  }));
 
-  const cacheValidity = await Promise.all(
-    cacheKeys.map(async entry => ({
-      category: entry.category,
-      hasCache: await hasValidCache(entry.key),
-    }))
-  );
-
-  if (!cacheValidity.every(result => result.hasCache)) {
-    return undefined;
-  }
-
-  const dataByCategory = await Promise.all(
-    cacheKeys.map(async entry => [
-      entry.category,
-      await getCacheData(entry.key),
-    ] as const)
-  );
-
-  const selectionsByCategory = Object.fromEntries(dataByCategory) as HistoricalEventsByCategory;
-  const hasAnySelection = HISTORICAL_EVENT_CATEGORIES.some(category => !isEmptySelection(selectionsByCategory[category]));
-
-  return hasAnySelection ? selectionsByCategory : undefined;
+  return Object.fromEntries(entries) as HistoricalEventsByCategory;
 }
 
 async function getVisibleSelection(selection: CachedHistoricalEventSelection): Promise<CachedHistoricalEvent[]> {
-  const visibleEvents = await filterHiddenContent(selection.events);
-  return visibleEvents.slice(0, selection.count);
+  return filterHiddenContent(selection.events);
 }
 
 async function getVisibleSelectionsByCategory(selections: HistoricalEventsByCategory): Promise<Record<HistoricalEventCategory, CachedHistoricalEvent[]>> {
@@ -117,6 +210,87 @@ function emptySelectionsByCategory(): HistoricalEventsByCategory {
   return Object.fromEntries(
     HISTORICAL_EVENT_CATEGORIES.map(category => [category, emptySelection()] as const)
   ) as HistoricalEventsByCategory;
+}
+
+function finalizeSelection(
+  primary: CachedHistoricalEventSelection,
+  refill: CachedHistoricalEventSelection = emptySelection()
+): CachedHistoricalEventSelection {
+  const selection = mergeValidatedSelections(primary, refill);
+  return hasMinimumEvents(selection) ? selection : emptySelection();
+}
+
+async function generateCompleteBatch(
+  date: string,
+  viewType: 'today' | 'week',
+  cachedSelections: HistoricalEventsByCategory
+): Promise<HistoricalEventsByCategory> {
+  const missingCachedCategories = HISTORICAL_EVENT_CATEGORIES.filter(category => !hasMinimumEvents(cachedSelections[category]));
+
+  if (missingCachedCategories.length < HISTORICAL_EVENT_CATEGORIES.length) {
+    const refill = await generateHistoricalEventRefill({
+      date,
+      viewType,
+      categories: missingCachedCategories,
+      excludedEvents: HISTORICAL_EVENT_CATEGORIES.flatMap(category => cachedSelections[category]?.events || []),
+    });
+    const validatedRefill = await validateCategorySources(refill);
+
+    return Object.fromEntries(
+      HISTORICAL_EVENT_CATEGORIES.map(category => [
+        category,
+        finalizeSelection(cachedSelections[category], validatedRefill[category]),
+      ])
+    ) as HistoricalEventsByCategory;
+  }
+
+  const generated = await generateHistoricalEventsByCategory({ date, viewType, category: 'Sociology' });
+  const validated = await validateCategorySources(generated);
+  const deficientCategories = HISTORICAL_EVENT_CATEGORIES.filter(category => !hasMinimumEvents(validated[category]));
+
+  if (deficientCategories.length === 0) {
+    return Object.fromEntries(
+      HISTORICAL_EVENT_CATEGORIES.map(category => [category, finalizeSelection(validated[category])])
+    ) as HistoricalEventsByCategory;
+  }
+
+  const refill = await generateHistoricalEventRefill({
+    date,
+    viewType,
+    categories: deficientCategories,
+    excludedEvents: HISTORICAL_EVENT_CATEGORIES.flatMap(category => generated[category]?.events || []),
+  });
+  const validatedRefill = await validateCategorySources(refill);
+
+  return Object.fromEntries(
+    HISTORICAL_EVENT_CATEGORIES.map(category => [
+      category,
+      finalizeSelection(validated[category], validatedRefill[category]),
+    ])
+  ) as HistoricalEventsByCategory;
+}
+
+async function generateCompleteSelection(
+  date: string,
+  viewType: 'today' | 'week',
+  category: HistoricalEventCategory
+): Promise<CachedHistoricalEventSelection> {
+  const generated = await generateHistoricalEvents({ date, viewType, category });
+  const validated = await validateSelectionSources(generated);
+
+  if (hasMinimumEvents(validated)) {
+    return finalizeSelection(validated);
+  }
+
+  const refill = await generateHistoricalEventRefill({
+    date,
+    viewType,
+    categories: [category],
+    excludedEvents: generated.events,
+  });
+  const validatedRefill = await validateSelectionSources(refill[category] || emptySelection());
+
+  return finalizeSelection(validated, validatedRefill);
 }
 
 async function runLockedGeneration<T>(options: {
@@ -257,7 +431,7 @@ export async function GET(request: NextRequest) {
 
       console.log('Fetching fresh data from Gemini API for all categories');
 
-      if (!process.env.GOOGLE_GENAI_API_KEY && !process.env.GOOGLE_API_KEY) {
+      if (!process.env.GOOGLE_GENAI_API_KEY && !process.env.GOOGLE_API_KEY && !process.env.GEMINI_API_KEY) {
         console.error('Google Gemini API key not configured');
         return NextResponse.json({
           error: 'API key not configured. Please set GOOGLE_GENAI_API_KEY in your environment variables.',
@@ -273,21 +447,17 @@ export async function GET(request: NextRequest) {
         runLockedGeneration<HistoricalEventsByCategory>({
           lockKey,
           readCachedData: async () => getCachedBatchResponse(date, viewType as 'today' | 'week'),
-          generateFreshData: async () => {
-            const generatedEvents = await generateHistoricalEventsByCategory({
-              date,
-              viewType: viewType as 'today' | 'week',
-              category: 'Sociology'
-            });
-
-            return generatedEvents;
-          },
+          generateFreshData: async () => generateCompleteBatch(
+            date,
+            viewType as 'today' | 'week',
+            await getCachedSelectionsByCategory(date, viewType as 'today' | 'week')
+          ),
           storeFreshData: async generatedEventsByCategory => {
             await Promise.all(
               HISTORICAL_EVENT_CATEGORIES.map(async currentCategory => {
                 const cachedEvents = generatedEventsByCategory[currentCategory] || { count: 0, events: [] };
 
-                if (isEmptySelection(cachedEvents)) {
+                if (!hasMinimumEvents(cachedEvents)) {
                   return;
                 }
 
@@ -314,6 +484,7 @@ export async function GET(request: NextRequest) {
         dataByCategory: eventsByCategory,
         visibleEventsByCategory,
         cached,
+        reportCacheRevision: buildReportCacheRevision(await getReportStats()),
         timestamp: new Date().toISOString()
       });
     }
@@ -345,7 +516,7 @@ export async function GET(request: NextRequest) {
     console.log(`Fetching fresh data from Gemini API for: ${key}`);
     
     // Check if API key is configured
-    if (!process.env.GOOGLE_GENAI_API_KEY && !process.env.GOOGLE_API_KEY) {
+    if (!process.env.GOOGLE_GENAI_API_KEY && !process.env.GOOGLE_API_KEY && !process.env.GEMINI_API_KEY) {
       console.error('Google Gemini API key not configured');
       return NextResponse.json({
         error: 'API key not configured. Please set GOOGLE_GENAI_API_KEY in your environment variables.',
@@ -361,13 +532,13 @@ export async function GET(request: NextRequest) {
       runLockedGeneration({
       lockKey,
       readCachedData: async () => getCachedSingleCategoryResponse(key),
-      generateFreshData: async () => generateHistoricalEvents({
+      generateFreshData: async () => generateCompleteSelection(
         date,
-        viewType: viewType as 'today' | 'week',
-        category: category as HistoricalEventCategory
-      }),
+        viewType as 'today' | 'week',
+        category as HistoricalEventCategory
+      ),
       storeFreshData: async generatedEvents => {
-        if (isEmptySelection(generatedEvents)) {
+        if (!hasMinimumEvents(generatedEvents)) {
           return;
         }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,6 +14,7 @@ import { useHeaderShrink } from "@/hooks/use-header-shrink";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useToast } from "@/hooks/use-toast";
 import { HISTORICAL_EVENT_CATEGORIES, type HistoricalEventCategory } from "@/lib/historical-event-categories";
+import { MINIMUM_PUBLISHABLE_EVENTS } from "@/lib/historical-event-selection";
 import { normalizeCacheDate } from "@/lib/cache-keys";
 import {
   AlertDialog,
@@ -58,7 +59,7 @@ type ClientCacheEntry<T> = {
 };
 
 const CLIENT_CACHE_PREFIX = "chronolens_client_events";
-const CLIENT_CACHE_VERSION = "v6";
+const CLIENT_CACHE_VERSION = "v10";
 const REPORTED_CONTENT_CACHE_KEY = "chronolens_reported_content_v1";
 const HIDDEN_CONTENT_CACHE_KEY = "chronolens_hidden_content_v1";
 const clientCacheMemory = new Map<string, ClientCacheEntry<unknown>>();
@@ -224,8 +225,12 @@ function getClientCacheExpiration(viewType: 'today' | 'week'): number {
   return now.getTime() + (14 * 24 * 60 * 60 * 1000);
 }
 
-function hasAnyHistoricalEventsByCategory(eventsByCategory: Record<HistoricalEventCategory, HistoricalEventSelection>): boolean {
-  return Object.values(eventsByCategory).some(selection => Array.isArray(selection?.events) && selection.events.length > 0);
+function hasCompleteHistoricalEventsByCategory(eventsByCategory: Partial<Record<HistoricalEventCategory, HistoricalEventSelection & { visibleEvents?: HistoricalEvent[] }>>): boolean {
+  return HISTORICAL_EVENT_CATEGORIES.every(category => {
+    const selection = eventsByCategory[category];
+    const events = selection?.visibleEvents ?? selection?.events ?? [];
+    return (selection?.count || 0) >= MINIMUM_PUBLISHABLE_EVENTS && events.length >= MINIMUM_PUBLISHABLE_EVENTS;
+  });
 }
 
 function getClientCache<T>(key: string): T | undefined {
@@ -424,7 +429,7 @@ async function getHistoricalEventsForCategory(category: string, isTodayView: boo
       visibleEvents: Array.isArray(result.visibleEvents) ? result.visibleEvents : [],
     };
 
-    if (payload.events.length > 0) {
+    if (payload.count >= MINIMUM_PUBLISHABLE_EVENTS && payload.visibleEvents.length >= MINIMUM_PUBLISHABLE_EVENTS) {
       setClientCache(clientCacheKey, payload, viewType, result.reportCacheRevision);
     }
     
@@ -449,7 +454,7 @@ async function getHistoricalEventsForAllCategories(isTodayView: boolean, dateStr
   const cachedClientData = getClientCache<HistoricalEventsByCategory>(clientCacheKey);
   if (cachedClientData) {
     const memoryEntry = clientCacheMemory.get(clientCacheKey);
-    if (!reportCacheRevision || memoryEntry?.revision === reportCacheRevision) {
+    if (hasCompleteHistoricalEventsByCategory(cachedClientData) && (!reportCacheRevision || memoryEntry?.revision === reportCacheRevision)) {
     console.log(`All categories served from client cache`);
     return {
       eventsByCategory: cachedClientData,
@@ -494,7 +499,7 @@ async function getHistoricalEventsForAllCategories(isTodayView: boolean, dateStr
 
   console.log(`All categories ${result.cached ? 'served from cache' : 'fetched fresh from API'}`);
 
-  if (result.dataByCategory && hasAnyHistoricalEventsByCategory(result.dataByCategory)) {
+  if (hasCompleteHistoricalEventsByCategory(eventsByCategory)) {
     setClientCache(clientCacheKey, eventsByCategory, viewType, result.reportCacheRevision);
   }
 
@@ -630,11 +635,13 @@ export default function Home() {
     }
 
     const hiddenKeys = new Set(Object.keys(hiddenContent).filter(key => hiddenContent[key]));
-    const sourceEvents = Array.isArray(selection.visibleEvents) && selection.visibleEvents.length > 0
+    const sourceEvents = Array.isArray(selection.visibleEvents)
       ? selection.visibleEvents
       : selection.events.slice(0, selection.count);
 
-    return sourceEvents.filter(event => !hiddenKeys.has(getEventReportKey(event)));
+    return sourceEvents
+      .filter(event => !hiddenKeys.has(getEventReportKey(event)))
+      .slice(0, selection.count);
   };
 
   useEffect(() => {
@@ -709,7 +716,7 @@ export default function Home() {
     
     try {
       const {eventsByCategory, cached} = await getHistoricalEventsForAllCategories(isTodayView, dateString);
-      const hasEvents = hasAnyHistoricalEventsByCategory(eventsByCategory);
+      const hasCompleteEvents = hasCompleteHistoricalEventsByCategory(eventsByCategory);
 
       setHistoricalEvents(prev => ({
         ...prev,
@@ -723,7 +730,7 @@ export default function Home() {
         }, {} as Record<string, boolean>)
       );
 
-      if (!cached && !hasEvents && shouldKeepWarmupVisible) {
+      if (!cached && !hasCompleteEvents && shouldKeepWarmupVisible) {
         batchRetryTimerRef.current = window.setTimeout(() => {
           void fetchAllEvents();
         }, 10000);
@@ -1561,4 +1568,3 @@ export default function Home() {
     </div>
   );
 }
-

--- a/src/lib/gemini-prompt-builders.ts
+++ b/src/lib/gemini-prompt-builders.ts
@@ -11,6 +11,13 @@ export type HistoricalEventWeekInfo = {
   endDate: string;
 };
 
+export type HistoricalEventRefillInput = {
+  date: string;
+  categories: string[];
+  excludedEvents: Array<{ category: string; title: string; source: string }>;
+  weekInfo?: HistoricalEventWeekInfo;
+};
+
 const EVENT_SELECTION_GUIDANCE = [
   'Return a JSON object with a count field between 3 and 5.',
   'Return an events array containing at least 6 candidate events ordered from most significant to least significant.',
@@ -60,4 +67,33 @@ export function buildBatchEventWeekPrompt(date: string, weekInfo: HistoricalEven
     'For each category, return a JSON object that follows this selection format:',
     EVENT_SELECTION_GUIDANCE,
   ].join('\n');
+}
+
+export function buildRefillEventPrompt(input: HistoricalEventRefillInput): string {
+  const dateRule = input.weekInfo
+    ? `Every event must fall between ${input.weekInfo.startDate} and ${input.weekInfo.endDate} (MM-DD).`
+    : 'Every event must match the exact same month and day as the requested date.';
+  const exclusions = input.excludedEvents.length > 0
+    ? input.excludedEvents.map(event => `- ${event.category}: ${event.title} | ${event.source}`).join('\n')
+    : '- None';
+
+  return [
+    'Generate replacement historical-event candidates for only the requested categories.',
+    `Date: ${input.date}`,
+    input.weekInfo ? `Week range: ${input.weekInfo.monthDay}` : '',
+    `Categories: ${input.categories.join(', ')}`,
+    dateRule,
+    'Return at least 12 new candidates for each requested category.',
+    'Do not repeat any excluded title or source URL.',
+    'Use confident, live, permanent source URLs that directly verify each event.',
+    'Prefer canonical English Wikipedia articles and official government, university, archive, or museum pages.',
+    'Avoid news articles, publisher marketing pages, URL shorteners, and deep links likely to block automated access.',
+    'When uncertain about a deep link, use the canonical Wikipedia biography or event article.',
+    'Do not guess or fabricate URLs.',
+    'Descriptions must be 50-100 words.',
+    'Return JSON in this exact shape: {"events":[...]}.',
+    'Each event must include title, date, description, category, source, and significanceRank.',
+    'Excluded events:',
+    exclusions,
+  ].filter(Boolean).join('\n');
 }

--- a/src/lib/historical-event-selection.ts
+++ b/src/lib/historical-event-selection.ts
@@ -1,0 +1,46 @@
+import type { CachedHistoricalEventSelection } from './cache-file';
+
+export const MINIMUM_PUBLISHABLE_EVENTS = 3;
+export const MAXIMUM_PUBLISHABLE_EVENTS = 5;
+export const MAXIMUM_STORED_EVENTS = 6;
+
+export function hasMinimumEvents(selection?: CachedHistoricalEventSelection | null): selection is CachedHistoricalEventSelection {
+  return Boolean(
+    selection &&
+    selection.count >= MINIMUM_PUBLISHABLE_EVENTS &&
+    Array.isArray(selection.events) &&
+    selection.events.length >= MINIMUM_PUBLISHABLE_EVENTS
+  );
+}
+
+export function mergeValidatedSelections(
+  primary: CachedHistoricalEventSelection,
+  refill: CachedHistoricalEventSelection
+): CachedHistoricalEventSelection {
+  const titles = new Set<string>();
+  const sources = new Set<string>();
+  const events = [...primary.events, ...refill.events]
+    .filter(event => {
+      const title = event.title.trim().toLowerCase();
+      const source = event.source.trim().toLowerCase();
+
+      if (titles.has(title) || sources.has(source)) {
+        return false;
+      }
+
+      titles.add(title);
+      sources.add(source);
+      return true;
+    })
+    .slice(0, MAXIMUM_STORED_EVENTS)
+    .map((event, index) => ({ ...event, significanceRank: index + 1 }));
+
+  return {
+    count: Math.min(
+      events.length,
+      MAXIMUM_PUBLISHABLE_EVENTS,
+      Math.max(MINIMUM_PUBLISHABLE_EVENTS, primary.count, refill.count)
+    ),
+    events,
+  };
+}


### PR DESCRIPTION
## Summary
- reject unreachable, unsupported, and soft-404 source pages
- make one conditional Gemini refill request for deficient categories
- require at least 3 verified events while preserving dynamic 3-5 display counts
- retain verified reserves and avoid caching incomplete server/client results

## Verification
- `npm run typecheck`
- `npm run test:content-refill`
- local API returned complete 3-5 event counts for all eight categories
- subsequent local API request was served from cache